### PR TITLE
feat : [001-initial-set] Jpa와 Jdbc의 차이와 test 구현

### DIFF
--- a/.jpb/persistence-units.xml
+++ b/.jpb/persistence-units.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PersistenceUnitSettings">
+    <persistence-units>
+      <persistence-unit name="Default">
+        <packages>
+          <package value="com.example.weather_example" />
+        </packages>
+      </persistence-unit>
+    </persistence-units>
+  </component>
+</project>

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
-//	implementation 'org.springframework.data:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/example/weather_example/domain/Memo.java
+++ b/src/main/java/com/example/weather_example/domain/Memo.java
@@ -1,0 +1,24 @@
+package com.example.weather_example.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity(name = "memo")
+public class Memo {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+    private String text;
+
+}

--- a/src/main/java/com/example/weather_example/repository/JdbcMemoRepository.java
+++ b/src/main/java/com/example/weather_example/repository/JdbcMemoRepository.java
@@ -1,0 +1,44 @@
+package com.example.weather_example.repository;
+
+import com.example.weather_example.domain.Memo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class JdbcMemoRepository {
+    private final JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    public JdbcMemoRepository(DataSource dataSource) {
+        jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    public Memo save(Memo memo) {
+        String sql = "insert into memo values(?,?)";
+        jdbcTemplate.update(sql, memo.getId(), memo.getText());
+        return memo;
+    }
+
+    public List<Memo> findAll() {
+        String sql = "select * from memo";
+        return jdbcTemplate.query(sql, memoRowMapper());
+    }
+
+    public Optional<Memo> findById(int id) {
+        String sql = "select * from memo where id = ?";
+        return jdbcTemplate.query(sql, memoRowMapper(), id).stream().findFirst();
+    }
+
+    private RowMapper<Memo> memoRowMapper() {
+        return ((rs, rowNum) -> new Memo(
+                rs.getInt("id"),
+                rs.getString("text")
+        ));
+    }
+}

--- a/src/main/java/com/example/weather_example/repository/JpaMemoRepository.java
+++ b/src/main/java/com/example/weather_example/repository/JpaMemoRepository.java
@@ -1,0 +1,12 @@
+package com.example.weather_example.repository;
+
+import com.example.weather_example.domain.Memo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JpaMemoRepository extends JpaRepository<Memo, Integer> {
+
+
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,7 @@
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=jdbc:mysql://localhost:3306/project?serverTimezone=UTF&characterEncoding=UTF-8
+spring.datasource.url=jdbc:mysql://localhost:3306/example?serverTimezone=UTC&characterEncoding=UTF-8
 spring.datasource.username=root
 spring.datasource.password=zerobase
+spring.jpa.show-sql=true
+spring.jpa.database=mysql
 

--- a/src/test/java/com/example/weather_example/JdbcMemoRepositoryTest.java
+++ b/src/test/java/com/example/weather_example/JdbcMemoRepositoryTest.java
@@ -1,0 +1,42 @@
+package com.example.weather_example;
+
+import com.example.weather_example.domain.Memo;
+import com.example.weather_example.repository.JdbcMemoRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+//@Transactional
+public class JdbcMemoRepositoryTest {
+
+    @Autowired
+    JdbcMemoRepository jdbcMemoRepository;
+
+    @Test
+    void insertMemoTest() {
+        //given
+        Memo newMemo = new Memo(2, "insertMemoTest");
+
+        //when
+        jdbcMemoRepository.save(newMemo);
+
+        //then
+        Optional<Memo> result = jdbcMemoRepository.findById(2);
+        assertEquals(result.get().getText(), "insertMemoTest");
+    }
+
+    @Test
+    void findAllMemoTest() {
+        List<Memo> memoList = jdbcMemoRepository.findAll();
+        System.out.println(memoList);
+        assertNotNull(memoList);
+    }
+
+}

--- a/src/test/java/com/example/weather_example/JpaMemoRepositoryTest.java
+++ b/src/test/java/com/example/weather_example/JpaMemoRepositoryTest.java
@@ -1,0 +1,49 @@
+package com.example.weather_example;
+
+import com.example.weather_example.domain.Memo;
+import com.example.weather_example.repository.JpaMemoRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@Transactional
+public class JpaMemoRepositoryTest {
+
+    @Autowired
+    JpaMemoRepository jpaMemoRepository;
+
+    @Test
+    void insertMemoTest() {
+        //given
+        Memo newMemo = new Memo(10, "this is jpa memo");
+
+        //when
+        jpaMemoRepository.save(newMemo);
+
+        //then
+        List<Memo> memoList = jpaMemoRepository.findAll();
+        assertTrue(memoList.size() > 0);
+    }
+
+    @Test
+    void findByIdTest() {
+        //given
+        Memo newMemo = new Memo(11, "jpa");
+
+        //when
+        Memo memo = jpaMemoRepository.save(newMemo);
+        System.out.println(memo.getId());
+
+        //then
+        Optional<Memo> result = jpaMemoRepository.findById(memo.getId());
+        assertEquals(result.get().getText(), "jpa");
+    }
+}


### PR DESCRIPTION
change
---
1.  초기설정
2.  jpa와 jdbc 구현 및 테스트를 통해 차이점 알기


summary
---
jpa는 sql를 자동생성(orm)
jdbc는 sql를 명시해줘야 한다(sql mapper)
